### PR TITLE
Enable use as pippable package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+
+# This version keeps the flat structure of pymira and avoids import nonsense
+# 1)    Bare install for just using it to convert amira files, possibly with editing (use [edit])
+#       will still install the remaining modules but not dependencies.
+# 2)    For complete workflows with plotting and skeletonisation, just use [full]
+#       (--dry-run suggests that up to 1GB of deps will be pulled in)
+
+# pip install 'pymira[extras] @ git+https://github.com/USERNAME/pymira.git'
+# Remember the quotation marks!
+
+extras_require = {
+    'stl': ['stl'],
+    'plot': ['matplotlib', 'open3d', 'pyvista', 'mayavi'],
+    'image': ['scikit-image', 'nibabel', 'opencv-python'],
+    'edit': ['scipy', 'dill']
+}
+full = list()
+for reqs in extras_require.values():
+    full.extend(reqs)
+extras_require['full'] = full
+
+setup(
+    name='pymira',
+    version='0.1',
+    packages=['pymira'],
+    package_dir={'pymira':''},
+    install_requires=['tqdm','numpy'],
+    extras_require=extras_require
+)

--- a/spatialgraph.py
+++ b/spatialgraph.py
@@ -13,8 +13,8 @@ import numpy as np
 arr = np.asarray
 import os
 from tqdm import tqdm, trange # progress bar
-import matplotlib as mpl
-from matplotlib import pyplot as plt
+#import matplotlib as mpl
+#from matplotlib import pyplot as plt
 
 def update_array_index(vals,inds,keep):
     # Updates/offets indices for an array (vals) to exclude values in a flag array (keep)


### PR DESCRIPTION
Allows installation with `pip install 'pymira[extras] @ git+https://github.com/cabi-sws/pymira.git'`, where extras can be any combination of:
- `edit`: adds `scipy`, `dill` for editing spatial graphs during conversion
- `plot`: adds `matplotlib` and `open3d`, `pyvista`, `mayavi` for workflows involving rendering
- `image`: adds `scikit-image`, `nibabel`, `opencv-python` for workflows involving skeletonisation to graphs
- `stl`: adds `stl` for the experimental surface support
- `full`

Default installation only adds `numpy`, `tqdm` for use as a file converter.

You should be able to add `pymira[extras] @ git+https://github.com/cabi-sws/pymira.git` to a `requirements.txt` file (without quotation marks) as well.